### PR TITLE
changed pyo3-pack to maturin - enables support for python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,6 @@ before_cache:
 before_install:
   - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
 
-install: pip install -U tox pyo3-pack tox-pyo3 tox-travis
+install: pip install -U tox maturin tox-pyo3 tox-travis
 
 script: tox

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ features = ["extension-module"]
 version = "0.8.1"
 features = ["v1", "v3", "v4", "v5"]
 
-[package.metadata.pyo3-pack]
+[package.metadata.maturin]
 classifier = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
@@ -28,6 +28,7 @@ classifier = [
   "Programming Language :: Python :: 3.5",
   "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules"

--- a/build_or_release.sh
+++ b/build_or_release.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [[ -z "${TRAVIS_TAG}" ]]; then
-  /opt/python/cp37-cp37m/bin/pyo3-pack build --manylinux $MANYLINUX_VERSION --release -i /opt/python/cp37-cp37m/bin/python -i /opt/python/cp36-cp36m/bin/python -i /opt/python/cp35-cp35m/bin/python
+  /opt/python/cp37-cp37m/bin/maturin build --manylinux $MANYLINUX_VERSION --release -i /opt/python/cp38-cp38/bin/python -i /opt/python/cp37-cp37m/bin/python -i /opt/python/cp36-cp36m/bin/python -i /opt/python/cp35-cp35m/bin/python
   ls -1 target/wheels/*.whl | xargs -I%  auditwheel show %
 else
-  /opt/python/cp37-cp37m/bin/pyo3-pack publish --username $PYPI_USERNAME --manylinux $MANYLINUX_VERSION -i /opt/python/cp37-cp37m/bin/python -i /opt/python/cp36-cp36m/bin/python -i /opt/python/cp35-cp35m/bin/python
+  /opt/python/cp37-cp37m/bin/maturin publish --username $PYPI_USERNAME --manylinux $MANYLINUX_VERSION -i /opt/python/cp38-cp38/bin/python -i /opt/python/cp37-cp37m/bin/python -i /opt/python/cp36-cp36m/bin/python -i /opt/python/cp35-cp35m/bin/python
 fi

--- a/manylinux1.dockerfile
+++ b/manylinux1.dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/pypa/manylinux1_x86_64:latest
 
 RUN curl -sSf https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
 ENV PATH /root/.cargo/bin:$PATH
-RUN /opt/python/cp37-cp37m/bin/pip install --pre maturin
+RUN /opt/python/cp37-cp37m/bin/pip install maturin
 
 RUN mkdir /tmp/src
 WORKDIR /tmp/src

--- a/manylinux1.dockerfile
+++ b/manylinux1.dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/pypa/manylinux1_x86_64:latest
 
 RUN curl -sSf https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
 ENV PATH /root/.cargo/bin:$PATH
-RUN /opt/python/cp37-cp37m/bin/pip install --pre pyo3-pack
+RUN /opt/python/cp37-cp37m/bin/pip install --pre maturin
 
 RUN mkdir /tmp/src
 WORKDIR /tmp/src

--- a/manylinux2010.dockerfile
+++ b/manylinux2010.dockerfile
@@ -4,7 +4,7 @@ RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
 ENV PATH /root/.cargo/bin:$PATH
 RUN rustup install nightly
 RUN rustup default nightly
-RUN /opt/python/cp37-cp37m/bin/pip install --pre pyo3-pack
+RUN /opt/python/cp37-cp37m/bin/pip install --pre maturin
 
 RUN mkdir /tmp/src
 WORKDIR /tmp/src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["pyo3-pack"]
-build-backend = "pyo3_pack"
+requires = ["maturin"]
+build-backend = "maturin"


### PR DESCRIPTION
This PR adds building of Python3.8 wheels (old pyo3-pack didn't support building for that version, due to expecting the m tag that was relevant in old versions)
Fixes #2 