### PR TITLE
Use #[derive(Clone)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ use uuid::{Builder, Uuid, Variant, Version};
 
 #[pymodule]
 fn fastuuid(_py: Python, m: &PyModule) -> PyResult<()> {
+
     #[pyclass(freelist = 1000)]
+    #[derive(Clone)]
     struct UUID {
         handle: Uuid,
     }
@@ -318,14 +320,6 @@ fn fastuuid(_py: Python, m: &PyModule) -> PyResult<()> {
         #[getter]
         fn node(&self) -> u64 {
             (self.int() & 0xffffffffffff) as u64
-        }
-    }
-
-    impl Clone for UUID {
-        fn clone(&self) -> Self {
-            UUID {
-                handle: self.handle,
-            }
         }
     }
 


### PR DESCRIPTION
The Rust compiler is able to automatically implement `Clone` using an attribute, as long as all the contained fields implement `Clone`.

This removes the need for the hand-written `Clone` implementation.

As the `uuid::Uuid` type implements `Copy`, you might even want to use `#[derive(Copy, Clone)]` here.