### PR TITLE
Pickle support + Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '3.8'
   - '3.9'
   - '3.10'
+  - '3.11'
 stages:
   - test
   - lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastuuid"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Omer Katz <omer.drow@gmail.com>"]
 license = "BSD3"
 description = "Python bindings to Rust's UUID library."
@@ -14,7 +14,7 @@ version = "0.17.1"
 features = ["extension-module"]
 
 [dependencies.uuid]
-version = "0.8.2"
+version = "1"
 features = ["v1", "v3", "v4", "v5"]
 
 [package.metadata.maturin]
@@ -29,6 +29,7 @@ classifier = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries",
   "Topic :: Software Development :: Libraries :: Python Modules"

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ FastUUID is a library which provides CPython bindings to Rust's UUID library.
 
 The provided API is exactly as Python's builtin UUID class.
 
-It is supported on Python 3.7, 3.8, 3.9 & 3.10.
+It is supported on Python 3.7, 3.8, 3.9, 3.10 & 3.11.
 
 Why?
 ----
@@ -60,6 +60,5 @@ What's Missing?
 ---------------
 
 - UUIDv1 generation
-- Pickle support
 
 PRs are welcome.

--- a/build_or_release.sh
+++ b/build_or_release.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [[ -z "${TRAVIS_TAG}" ]]; then
-  /opt/python/cp39-cp39/bin/maturin build --compatibility $MANYLINUX_VERSION --release -i /opt/python/cp310-cp310/bin/python -i /opt/python/cp39-cp39/bin/python -i /opt/python/cp38-cp38/bin/python -i /opt/python/cp37-cp37m/bin/python
+  /opt/python/cp39-cp39/bin/maturin build --compatibility $MANYLINUX_VERSION --release -i /opt/python/cp311-cp311/bin/python -i /opt/python/cp310-cp310/bin/python -i /opt/python/cp39-cp39/bin/python -i /opt/python/cp38-cp38/bin/python -i /opt/python/cp37-cp37m/bin/python
   ls -1 target/wheels/*.whl | xargs -I%  auditwheel show %
 else
-  /opt/python/cp39-cp39/bin/maturin publish ${NO_SDIST:+--no-sdist} --username $PYPI_USERNAME --compatibility $MANYLINUX_VERSION -i /opt/python/cp310-cp310/bin/python -i /opt/python/cp39-cp39/bin/python -i /opt/python/cp38-cp38/bin/python -i /opt/python/cp37-cp37m/bin/python
+  /opt/python/cp39-cp39/bin/maturin publish ${NO_SDIST:+--no-sdist} --username $PYPI_USERNAME --compatibility $MANYLINUX_VERSION -i /opt/python/cp311-cp311/bin/python -i /opt/python/cp310-cp310/bin/python -i /opt/python/cp39-cp39/bin/python -i /opt/python/cp38-cp38/bin/python -i /opt/python/cp37-cp37m/bin/python
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
 [build-system]
 requires = ["maturin>=0.12,<0.13"]
 build-backend = "maturin"
+
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,4 @@ from hypothesis import Verbosity, settings
 settings.register_profile("ci", max_examples=2000)
 settings.register_profile("dev", max_examples=100)
 settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
-settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'ci'))
+settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "ci"))

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,4 +1,6 @@
+import copy
 from concurrent.futures import ThreadPoolExecutor
+from pickle import dumps, loads
 from uuid import UUID, uuid3, uuid4, uuid5
 
 import pytest
@@ -15,87 +17,92 @@ def example():
     return uuid4()
 
 
-@pytest.mark.benchmark(group='parse-hex')
+@pytest.fixture(scope="session")
+def example_fastuuid():
+    return fastuuid4()
+
+
+@pytest.mark.benchmark(group="parse-hex")
 def test_parse_hex_uuid(benchmark, example):
     benchmark(UUID, hex=str(example))
 
 
-@pytest.mark.benchmark(group='parse-hex')
+@pytest.mark.benchmark(group="parse-hex")
 def test_parse_hex_fastuuid(benchmark, example):
     benchmark(FastUUID, hex=str(example))
 
 
-@pytest.mark.benchmark(group='parse-bytes')
+@pytest.mark.benchmark(group="parse-bytes")
 def test_parse_bytes_uuid(benchmark, example):
     benchmark(UUID, bytes=example.bytes)
 
 
-@pytest.mark.benchmark(group='parse-bytes')
+@pytest.mark.benchmark(group="parse-bytes")
 def test_parse_bytes_fastuuid(benchmark, example):
     benchmark(FastUUID, bytes=example.bytes)
 
 
-@pytest.mark.benchmark(group='parse-bytes_le')
+@pytest.mark.benchmark(group="parse-bytes_le")
 def test_parse_bytes_le_uuid(benchmark, example):
     benchmark(UUID, bytes_le=example.bytes_le)
 
 
-@pytest.mark.benchmark(group='parse-bytes_le')
+@pytest.mark.benchmark(group="parse-bytes_le")
 def test_parse_bytes_le_fastuuid(benchmark, example):
     benchmark(FastUUID, bytes_le=example.bytes_le)
 
 
-@pytest.mark.benchmark(group='parse-fields')
+@pytest.mark.benchmark(group="parse-fields")
 def test_parse_fields_uuid(benchmark, example):
     benchmark(UUID, fields=example.fields)
 
 
-@pytest.mark.benchmark(group='parse-fields')
+@pytest.mark.benchmark(group="parse-fields")
 def test_parse_fields_fastuuid(benchmark, example):
     benchmark(FastUUID, fields=example.fields)
 
 
-@pytest.mark.benchmark(group='parse-int')
+@pytest.mark.benchmark(group="parse-int")
 def test_parse_int_uuid(benchmark, example):
     benchmark(UUID, int=example.int)
 
 
-@pytest.mark.benchmark(group='parse-int')
+@pytest.mark.benchmark(group="parse-int")
 def test_parse_int_fastuuid(benchmark, example):
     benchmark(FastUUID, int=example.int)
 
 
-@pytest.mark.benchmark(group='uuidv3')
+@pytest.mark.benchmark(group="uuidv3")
 def test_uuidv3(benchmark):
     benchmark(uuid3, uuid4(), "benchmark")
 
 
-@pytest.mark.benchmark(group='uuidv3')
+@pytest.mark.benchmark(group="uuidv3")
 def test_fast_uuidv3(benchmark):
     benchmark(fastuuid3, fastuuid4(), b"benchmark")
 
 
-@pytest.mark.benchmark(group='uuidv4')
+@pytest.mark.benchmark(group="uuidv4")
 def test_uuidv4(benchmark):
     benchmark(uuid4)
 
 
-@pytest.mark.benchmark(group='uuidv4')
+@pytest.mark.benchmark(group="uuidv4")
 def test_fast_uuidv4(benchmark):
     benchmark(fastuuid4)
 
 
-@pytest.mark.benchmark(group='uuidv5')
+@pytest.mark.benchmark(group="uuidv5")
 def test_uuidv5(benchmark):
     benchmark(uuid5, uuid4(), "benchmark")
 
 
-@pytest.mark.benchmark(group='uuidv5')
+@pytest.mark.benchmark(group="uuidv5")
 def test_fast_uuidv5(benchmark):
     benchmark(fastuuid5, fastuuid4(), b"benchmark")
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads')
+@pytest.mark.benchmark(group="uuidv4 8 threads")
 def test_uuidv4_threads(benchmark):
     @benchmark
     def b():
@@ -105,7 +112,7 @@ def test_uuidv4_threads(benchmark):
         pool.shutdown(wait=True)
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads')
+@pytest.mark.benchmark(group="uuidv4 8 threads")
 def test_fast_uuidv4_threads(benchmark):
     @benchmark
     def b():
@@ -115,7 +122,7 @@ def test_fast_uuidv4_threads(benchmark):
         pool.shutdown(wait=True)
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads')
+@pytest.mark.benchmark(group="uuidv4 8 threads")
 def test_fast_uuidv4_bulk_threads(benchmark):
     @benchmark
     def b():
@@ -125,7 +132,7 @@ def test_fast_uuidv4_bulk_threads(benchmark):
         pool.shutdown(wait=True)
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads - strings')
+@pytest.mark.benchmark(group="uuidv4 8 threads - strings")
 def test_uuidv4_str_threads(benchmark):
     @benchmark
     def b():
@@ -135,7 +142,7 @@ def test_uuidv4_str_threads(benchmark):
         pool.shutdown(wait=True)
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads - strings')
+@pytest.mark.benchmark(group="uuidv4 8 threads - strings")
 def test_fast_uuidv4_str_threads(benchmark):
     @benchmark
     def b():
@@ -145,7 +152,7 @@ def test_fast_uuidv4_str_threads(benchmark):
         pool.shutdown(wait=True)
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads - strings')
+@pytest.mark.benchmark(group="uuidv4 8 threads - strings")
 def test_fast_uuidv4_bulk_convert_to_strings_threads(benchmark):
     @benchmark
     def b():
@@ -155,7 +162,7 @@ def test_fast_uuidv4_bulk_convert_to_strings_threads(benchmark):
         pool.shutdown(wait=True)
 
 
-@pytest.mark.benchmark(group='uuidv4 8 threads - strings')
+@pytest.mark.benchmark(group="uuidv4 8 threads - strings")
 def test_fast_uuidv4_as_strings_bulk_threads(benchmark):
     @benchmark
     def b():
@@ -163,3 +170,37 @@ def test_fast_uuidv4_as_strings_bulk_threads(benchmark):
         for _ in range(8):
             pool.submit(uuid4_as_strings_bulk, 1000)
         pool.shutdown(wait=True)
+
+
+def _pickle_unpickle(u):
+    return loads(dumps(u))
+
+
+@pytest.mark.benchmark(group="pickle")
+def test_pickle_unpickle(benchmark, example):
+    benchmark(_pickle_unpickle, example)
+
+
+@pytest.mark.benchmark(group="pickle")
+def test_pickle_unpickle_fastuuid(benchmark, example_fastuuid):
+    benchmark(_pickle_unpickle, example_fastuuid)
+
+
+@pytest.mark.benchmark(group="copy")
+def test_copy(benchmark, example):
+    benchmark(lambda u: copy.copy(u), example)
+
+
+@pytest.mark.benchmark(group="copy")
+def test_copy_fastuuid(benchmark, example_fastuuid):
+    benchmark(lambda u: copy.copy(u), example_fastuuid)
+
+
+@pytest.mark.benchmark(group="deep-copy")
+def test_deep_copy(benchmark, example):
+    benchmark(lambda u: copy.deepcopy(u), example)
+
+
+@pytest.mark.benchmark(group="deep-copy")
+def test_deep_copy_fastuuid(benchmark, example_fastuuid):
+    benchmark(lambda u: copy.deepcopy(u), example_fastuuid)

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,19 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, pypy3
+envlist = py37, py38, py39, py310, py311, pypy3
 requires = tox-pyo3
 
 [testenv]
 pyo3 = True
 deps =
+    black
+    isort
+    hypothesis
     pytest>=5.0
     pytest-benchmark
-    hypothesis
 commands =
     pytest -vvvv
+    black --check tests
+    isort --check-only tests
 skip_install = True


### PR DESCRIPTION
- Add pickle support
- Python 3.11 support
- Update rust UUID library dependency to version 1
- Apply black + isort formatting tools to python tests