### PR TITLE
GitHub Action to run tox and add Python 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,19 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox:
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]  #  [macos-latest, ubuntu-latest, windows-latest]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        os: [ubuntu-latest]  #  [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
     runs-on: ${{ matrix.os }}
     steps:
@@ -15,5 +15,5 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install --upgrade pip
-      - run: pip install tox tox_pyo3
+      - run: pip install tox git+https://github.com/thedrow/tox-pyo3
       - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: pip install --upgrade pip
-      - run: pip install tox
+      - run: pip install tox tox_pyo3
       - run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 # tox (https://tox.readthedocs.io/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
+# test suite on all supported Python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, py311, pypy3
+envlist = py37, py38, py39, py310, py311, py3.12, pypy3.10
 requires = tox-pyo3
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py3.12, pypy3.10
+envlist = py37, py38, py39, py310, py311, py3.12, pypy3
 requires = tox-pyo3
 
 [testenv]


### PR DESCRIPTION
Tox tests are failing at https://github.com/cclauss/fastuuid/actions because of thedrow/tox-pyo3#5