### PR TITLE
Build wheels for older manylinux platforms

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,9 +51,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install maturin twine
+          pip install maturin[zig] twine
       - name: Build wheels
-        run: maturin build --release
+        # Build a wheel for the current python version in release mode
+        # When running on linux, use zig to build the oldest possible manylinux wheel
+        # In addition, check the wheel with auditwheel, but without auto-repair
+        run: maturin build --release --compatibility --zig --auditwheel check
       - name: Build sdist
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
         run: maturin sdist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,6 +53,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install maturin[zig] twine
       - name: Build wheels
+        run: maturin build --release
+      - name: Build wheels for older linux versions
+        if: matrix.os == 'ubuntu-latest'
         # Build a wheel for the current python version in release mode
         # When running on linux, use zig to build the oldest possible manylinux wheel
         # In addition, check the wheel with auditwheel, but without auto-repair


### PR DESCRIPTION
With this change, a wheel like
'fastuuid-0.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64' is built. This is the oldest still possible manylinux version.

Closes #31