### PR TITLE
Upgrade from deprecated macos-13 to macos-15-intel in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,9 +44,9 @@ jobs:
           - { os: ubuntu-latest, target: aarch64, target-triple: aarch64-unknown-linux-gnu,            manylinux: auto, auditwheel: check }
           - { os: ubuntu-latest, target: aarch64, target-triple: aarch64-unknown-linux-musl,           manylinux: musllinux_1_1, auditwheel: repair }
 
-          - { os: macos-13, target: x86_64,     target-triple: x86_64-apple-darwin, auditwheel: check }
-          - { os: macos-13, target: aarch64,    target-triple: aarch64-apple-darwin, auditwheel: check }
-          - { os: macos-13, target: universal2, target-triple: x86_64-apple-darwin, auditwheel: check }
+          - { os: macos-15-intel, target: x86_64,     target-triple: x86_64-apple-darwin, auditwheel: check }
+          - { os: macos-15-intel, target: aarch64,    target-triple: aarch64-apple-darwin, auditwheel: check }
+          - { os: macos-15-intel, target: universal2, target-triple: x86_64-apple-darwin, auditwheel: check }
 
           - { os: windows-latest, target: x86_64, target-triple: x86_64-pc-windows-msvc, python-architecture: x64, auditwheel: check }
           - { os: windows-latest, target: i686,   target-triple: i686-pc-windows-msvc,   python-architecture: x86, auditwheel: check }


### PR DESCRIPTION
Replace GitHub Actions runner image `macos-13` with `macos-15-intel` as recommended in:
* https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down
> The macOS 13 runner image will be retired by ___December 4th, 2025___.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |