### PR TITLE
Add support for building and release Windows ARM64 wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,8 +15,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, windows-11-arm]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        exclude:
+          - os: windows-11-arm
+            python-version: '3.8'
+          - os: windows-11-arm
+            python-version: '3.9'
+          - os: windows-11-arm
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -50,6 +57,14 @@ jobs:
 
           - { os: windows-latest, target: x86_64, target-triple: x86_64-pc-windows-msvc, python-architecture: x64, auditwheel: check }
           - { os: windows-latest, target: i686,   target-triple: i686-pc-windows-msvc,   python-architecture: x86, auditwheel: check }
+          - { os: windows-11-arm, target: aarch64,   target-triple: aarch64-pc-windows-msvc,   python-architecture: arm64, auditwheel: check }
+        exclude:
+          - conf: { os: windows-11-arm }
+            python-version: '3.8'
+          - conf: { os: windows-11-arm }
+            python-version: '3.9'
+          - conf: { os: windows-11-arm }
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6


### PR DESCRIPTION
**PR Description:**
- Installing fastuuid via PIP distribution on Windows ARM64 currently fails due to unavailability of fastuuid wheels for Windows ARM64 architecture.
- Due to the above issue, many users may not be able to use fastuuid library natively on Windows ARM64.
- The PR adds CI support for building and releasing fastuuid on Windows ARM64

**Changes Proposed:**

- Added Windows ARM64 build configurations in the workflow file[workflows/[ci-cd.yml](https://github.com/fastuuid/fastuuid/compare/master...MugundanMCW:fastuuid:master#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4)].

**Installation logs:**
[logs.txt](https://github.com/user-attachments/files/25834151/logs.txt)
