### PR TITLE
Add armv7 wheel build in ci-cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,6 +43,8 @@ jobs:
           - { os: ubuntu-latest, target: i686,    target-triple: i686-unknown-linux-musl,              manylinux: musllinux_1_1, auditwheel: repair }
           - { os: ubuntu-latest, target: aarch64, target-triple: aarch64-unknown-linux-gnu,            manylinux: auto, auditwheel: check }
           - { os: ubuntu-latest, target: aarch64, target-triple: aarch64-unknown-linux-musl,           manylinux: musllinux_1_1, auditwheel: repair }
+          - { os: ubuntu-latest, target: armv7,   target-triple: armv7-unknown-linux-gnueabihf,        manylinux: auto, auditwheel: check }
+          - { os: ubuntu-latest, target: armv7,   target-triple: armv7-unknown-linux-musleabihf,       manylinux: musllinux_1_1, auditwheel: repair }
 
           - { os: macos-13, target: x86_64,     target-triple: x86_64-apple-darwin, auditwheel: check }
           - { os: macos-13, target: aarch64,    target-triple: aarch64-apple-darwin, auditwheel: check }


### PR DESCRIPTION
This PR adds CI support for building `armv7` (`gnueabihf` and `musleabihf`) Python wheels, which eliminates the need to compile from source for users on Raspberry Pi, various SBCs lacking system package managers for Rust toolchain support (e.g. embedded devices using buildroot).