### PR TITLE
Adapt for `uuid::Context` renaming in v1.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.26"
 features = ["extension-module"]
 
 [dependencies.uuid]
-version = "1"
+version = "1.23"
 features = ["v1", "v3", "v4", "v5", "v7"]
 
 [profile.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use rand::random;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::iter;
-use uuid::{Builder, Context, Timestamp, Uuid, Variant, Version};
+use uuid::{Builder, ContextV1, Timestamp, Uuid, Variant, Version};
 
 /// Generate a random node ID.
 /// In hope to be compliant with RFC4122, we set the multicast bit to 1.
@@ -460,9 +460,9 @@ mod fastuuid {
         };
         Ok(match clock_seq {
             Some(clock_seq) => {
-                // Timestamp::now(Context::new(clock_seq)) acquires an Atomic<u16>.
+                // Timestamp::now(ContextV1::new(clock_seq)) acquires an Atomic<u16>.
                 // If we can avoid it, we can probably get another performance boost.
-                let ts = Timestamp::now(Context::new(clock_seq));
+                let ts = Timestamp::now(ContextV1::new(clock_seq));
                 UUID {
                     handle: Uuid::new_v1(ts, &node),
                 }


### PR DESCRIPTION
Use `uuid::ContextV1` instead of `uuid::Context`, now a deprecated type alias; this avoids a warning (treated as an error in this project). Since we need `uuid::ContextV1` to exist, upgrade the `uuid` dependency from `1` to `1.23`.

----

This avoids:

```
$ cargo test
   Compiling fastuuid v0.14.0 (/home/ben/src/forks/fastuuid)
error: use of deprecated type alias `uuid::Context`: renamed to `ContextV1`
  --> src/lib.rs:14:21
   |
14 | use uuid::{Builder, Context, Timestamp, Uuid, Variant, Version};
   |                     ^^^^^^^
   |
note: the lint level is defined here
  --> src/lib.rs:1:9
   |
 1 | #![deny(warnings)]
   |         ^^^^^^^^
   = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`

error: use of deprecated type alias `uuid::Context`: renamed to `ContextV1`
   --> src/lib.rs:465:41
    |
465 |                 let ts = Timestamp::now(Context::new(clock_seq));
    |                                         ^^^^^^^

error: could not compile `fastuuid` (lib test) due to 2 previous errors
```

----

This PR obsoletes https://github.com/fastuuid/fastuuid/pull/46.