### PR TITLE
Fix invalid SPDX in license metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fastuuid"
 version = "0.14.0"
 authors = ["Omer Katz <omer.drow@gmail.com>"]
-license = "BSD3"
+license = "BSD-3-Clause"
 description = "Python bindings to Rust's UUID library."
 edition = "2021"
 


### PR DESCRIPTION
Replace `BSD3` with [`BSD-3-Clause`](https://spdx.org/licenses/BSD-3-Clause.html).